### PR TITLE
fix: set %dev http.port to 18220 (was 18120)

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,7 +43,7 @@ quarkus.flyway.migrate-at-start=true
 %dev.quarkus.flyway.clean-at-start=true
 quarkus.flyway.locations=classpath:db/migration
 # Dev configuration
-%dev.quarkus.http.port=18120
+%dev.quarkus.http.port=18220
 %dev.quarkus.http.host=0.0.0.0
 # Test configuration
 %test.quarkus.http.test-port=0


### PR DESCRIPTION
%dev previously matched the base port (both 18120). Updates the dev override to 18220 per the connector / sink / processing-module convention of base+100 in dev.